### PR TITLE
feat: add configuration file support and profile feature

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -35,7 +35,10 @@ func New(o Options) (*CLI, error) {
 	}
 
 	// Flags
-	var configPath string
+	var (
+		configPath string
+		profile    = qwriter.DefaultProfile.Name
+	)
 
 	// Setup
 	cli := &CLI{
@@ -57,6 +60,11 @@ func New(o Options) (*CLI, error) {
 				cli.config = config
 			}
 
+			err := cli.setProfile(profile)
+			if err != nil {
+				return err
+			}
+
 			txt := args[0]
 			s, err := cli.writer.Suggestions(txt)
 			if err != nil {
@@ -73,6 +81,7 @@ func New(o Options) (*CLI, error) {
 	cli.cmd.SetOut(cli.stdout)
 	cli.cmd.SetErr(cli.stderr)
 	cli.cmd.Flags().StringVarP(&configPath, "config", "c", "", "Path to the QWriter CLI configuration file")
+	cli.cmd.Flags().StringVarP(&profile, "profile", "p", qwriter.DefaultProfile.Name, "	Profile to use for reviewing and generating text")
 
 	return cli, nil
 }
@@ -86,4 +95,32 @@ func (cli *CLI) Execute() error {
 func (cli *CLI) Run(args []string) error {
 	cli.cmd.SetArgs(args)
 	return cli.Execute()
+}
+
+func (cli *CLI) setProfile(name string) error {
+	if name == qwriter.DefaultProfile.Name {
+		cli.writer.SetProfile(qwriter.DefaultProfile)
+		return nil
+	}
+
+	var profiles []qwriter.Profile
+	if cli.config != nil {
+		profiles = cli.config.Profiles
+	}
+
+	var selected qwriter.Profile
+	for _, p := range profiles {
+		if p.Name == name {
+			selected = p
+			break
+		}
+	}
+
+	//	A profile is required; display an error if it is not found.
+	if selected.Name != "" {
+		cli.writer.SetProfile(selected)
+		return nil
+	}
+
+	return fmt.Errorf("profile %s not found", name)
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -14,6 +14,7 @@ type CLI struct {
 	cmd    *cobra.Command
 	stdout io.Writer
 	stderr io.Writer
+	config *Config
 }
 
 type Options struct {
@@ -33,17 +34,29 @@ func New(o Options) (*CLI, error) {
 		return nil, errors.New("cli.Options.Stderr is required")
 	}
 
+	// Flags
+	var configPath string
+
 	// Setup
 	cli := &CLI{
 		writer: o.Writer,
 		stdout: o.Stdout,
 		stderr: o.Stderr,
+		config: nil,
 	}
 	cli.cmd = &cobra.Command{
 		Use:   "qwriter [text]",
 		Short: "QWriter CLI is a tool to generate and write text using OpenAI's GPT-4 model.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if configPath != "" {
+				config, err := NewConfig(configPath)
+				if err != nil {
+					return fmt.Errorf("failed to load configuration file: %w", err)
+				}
+				cli.config = config
+			}
+
 			txt := args[0]
 			s, err := cli.writer.Suggestions(txt)
 			if err != nil {
@@ -59,6 +72,7 @@ func New(o Options) (*CLI, error) {
 	}
 	cli.cmd.SetOut(cli.stdout)
 	cli.cmd.SetErr(cli.stderr)
+	cli.cmd.Flags().StringVarP(&configPath, "config", "c", "", "Path to the QWriter CLI configuration file")
 
 	return cli, nil
 }

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -2,6 +2,8 @@ package cli_test
 
 import (
 	"bytes"
+	"os"
+	"path"
 	"testing"
 
 	"github.com/BrunoQuaresma/openwritter/cli"
@@ -31,6 +33,66 @@ func TestCLI_TextOutput(t *testing.T) {
 		{Original: text, Value: "improved text"},
 	})
 	cli.Run([]string{text})
+
+	// Then return the improved text without errors
+	require.Empty(t, stdError.String())
+	require.Equal(t, "improved text\n", stdOut.String())
+}
+
+func TestCLI_NonExistentProfile(t *testing.T) {
+	t.Parallel()
+
+	var (
+		stdError bytes.Buffer
+		stdOut   bytes.Buffer
+		w        testutils.MockWriter
+	)
+	cli, err := cli.New(cli.Options{
+		Writer: &w,
+		Stderr: &stdError,
+		Stdout: &stdOut,
+	})
+	require.NoError(t, err)
+
+	// When passing an invalid profile to the command
+	cli.Run([]string{"improve this text", "-p", "nonexistent"})
+
+	// Then return an error message
+	require.NotEmpty(t, stdError)
+	require.Contains(t, stdError.String(), "profile nonexistent not found")
+}
+
+func TestCLI_ProfileFromConfig(t *testing.T) {
+	t.Parallel()
+
+	var (
+		stdError bytes.Buffer
+		stdOut   bytes.Buffer
+		w        testutils.MockWriter
+	)
+	cli, err := cli.New(cli.Options{
+		Writer: &w,
+		Stderr: &stdError,
+		Stdout: &stdOut,
+	})
+	require.NoError(t, err)
+
+	// Setup config
+	tmp := t.TempDir()
+	configPath := path.Join(tmp, ".qwriter.yaml")
+	yaml := `
+profiles:
+  - name: "ui-copy"
+    description: "generate and review text for the ui"
+`
+	os.WriteFile(configPath, []byte(yaml), 0644)
+
+	// Pass the config path to the command and a profile from the config
+	text := "improve this text"
+	w.SetSuggestions(text, []qwriter.Suggestion{
+		{Original: text, Value: "improved text"},
+	})
+	cli.Run([]string{text, "-c", configPath, "-p", "ui-copy"})
 
 	// Then return the improved text without errors
 	require.Empty(t, stdError.String())

--- a/cli/config.go
+++ b/cli/config.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Config struct {
+	path     string
+	Profiles []Profile `yaml:"profiles"`
+}
+
+type Profile struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+}
+
+func NewConfig(path string) (*Config, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := &Config{path: path}
+	err = yaml.Unmarshal(raw, &cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}

--- a/cli/config.go
+++ b/cli/config.go
@@ -3,17 +3,13 @@ package cli
 import (
 	"os"
 
+	"github.com/BrunoQuaresma/openwritter/pkg/qwriter"
 	"gopkg.in/yaml.v3"
 )
 
 type Config struct {
 	path     string
-	Profiles []Profile `yaml:"profiles"`
-}
-
-type Profile struct {
-	Name        string `yaml:"name"`
-	Description string `yaml:"description"`
+	Profiles []qwriter.Profile `yaml:"profiles"`
 }
 
 func NewConfig(path string) (*Config, error) {

--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -1,0 +1,55 @@
+package cli_test
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/BrunoQuaresma/openwritter/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid path", func(t *testing.T) {
+		t.Parallel()
+
+		path := "invalid-path"
+		_, err := cli.NewConfig(path)
+		require.Error(t, err)
+		require.EqualError(t, err, "open invalid-path: no such file or directory")
+	})
+
+	t.Run("invalid yaml", func(t *testing.T) {
+		t.Parallel()
+
+		tmp := t.TempDir()
+		configPath := path.Join(tmp, "config.yaml")
+		err := os.WriteFile(configPath, []byte("invalid-yaml"), 0644)
+		require.NoError(t, err)
+
+		_, err = cli.NewConfig(configPath)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "unmarshal errors")
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+
+		tmp := t.TempDir()
+		configPath := path.Join(tmp, "config.yaml")
+		yaml := `
+profiles:
+  - name: "Development"
+    description: "Profile for development environment"
+`
+		err := os.WriteFile(configPath, []byte(yaml), 0644)
+		require.NoError(t, err)
+
+		cfg, err := cli.NewConfig(configPath)
+		require.NoError(t, err)
+		require.Equal(t, cfg.Profiles[0].Name, "Development")
+		require.Equal(t, cfg.Profiles[0].Description, "Profile for development environment")
+	})
+}

--- a/cli/testutils/mockwriter.go
+++ b/cli/testutils/mockwriter.go
@@ -34,3 +34,5 @@ func (m *MockWriter) SetSuggestions(text string, suggestions []qwriter.Suggestio
 	}
 	m.SuggestionsByText[text] = suggestions
 }
+
+func (m *MockWriter) SetProfile(qwriter.Profile) {}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,8 +19,7 @@ func main() {
 		os.Exit(1)
 	}
 	w := qwriter.New(qwriter.Options{
-		AI:      ai.NewOpenAI(os.Getenv("QWRITER_OPENAI_KEY")),
-		Profile: qwriter.DefaultProfile,
+		AI: ai.NewOpenAI(os.Getenv("QWRITER_OPENAI_KEY")),
 	})
 	cli, err := cli.New(cli.Options{
 		Writer: w,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,7 +18,10 @@ func main() {
 		fmt.Fprintln(stderr, "Please, set the QWRITER_OPENAI_KEY environment variable with your OpenAI key.")
 		os.Exit(1)
 	}
-	w := qwriter.New(ai.NewOpenAI(os.Getenv("QWRITER_OPENAI_KEY")))
+	w := qwriter.New(qwriter.Options{
+		AI:      ai.NewOpenAI(os.Getenv("QWRITER_OPENAI_KEY")),
+		Profile: qwriter.DefaultProfile,
+	})
 	cli, err := cli.New(cli.Options{
 		Writer: w,
 		Stdout: stdout,

--- a/pkg/qwriter/profiles.go
+++ b/pkg/qwriter/profiles.go
@@ -1,0 +1,11 @@
+package qwriter
+
+type Profile struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+}
+
+var DefaultProfile = Profile{
+	Name:        "Default",
+	Description: "Correct any grammar and spelling errors and enhance the clarity and tone of the text.",
+}

--- a/pkg/qwriter/profiles.go
+++ b/pkg/qwriter/profiles.go
@@ -6,6 +6,6 @@ type Profile struct {
 }
 
 var DefaultProfile = Profile{
-	Name:        "Default",
-	Description: "Correct any grammar and spelling errors and enhance the clarity and tone of the text.",
+	Name:        "default",
+	Description: "correct any grammar and spelling errors and enhance the clarity and tone of the text.",
 }

--- a/pkg/qwriter/qwriter.go
+++ b/pkg/qwriter/qwriter.go
@@ -3,6 +3,7 @@ package qwriter
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/BrunoQuaresma/openwritter/pkg/qwriter/ai"
@@ -19,23 +20,32 @@ type Suggestion struct {
 }
 
 type qwriter struct {
-	ai ai.Client
+	ai      ai.Client
+	profile Profile
 }
 
-func New(ai ai.Client) Writer {
+type Options struct {
+	AI      ai.Client
+	Profile Profile
+}
+
+func New(o Options) Writer {
 	return &qwriter{
-		ai: ai,
+		ai:      o.AI,
+		profile: o.Profile,
 	}
 }
 
-const prompt = "You will be provided with text or code containing user-facing text. Your task is to correct any grammar and spelling errors and enhance the clarity and tone of the copy." +
-	"Focus only on the text visible to the user, ignoring any code-related issues or comments." +
+// Adding this prompt after the profile prompt ensures that the suggestions are
+// returned in the expected format.
+const prompt = "You will be provided with text or code. Your task is to %s. " +
+	"Focus only on the text, ignoring any code-related words. " +
 	"After making improvements, return a JSON array where each element includes the original text and its corresponding suggestion in this format: { original: \"...\", value: \"...\" }."
 
 func (w *qwriter) Suggestions(text string) ([]Suggestion, error) {
 	ctx := context.Background()
 
-	w.ai.SetPrompt(prompt)
+	w.ai.SetPrompt(fmt.Sprintf(prompt, w.profile.Description))
 	resp, err := w.ai.SendMessage(ctx, text)
 	if err != nil {
 		return []Suggestion{}, err

--- a/pkg/qwriter/qwriter.go
+++ b/pkg/qwriter/qwriter.go
@@ -10,6 +10,7 @@ import (
 )
 
 type Writer interface {
+	SetProfile(Profile)
 	Suggestions(text string) ([]Suggestion, error)
 	Apply(text string, suggestions []Suggestion) (string, error)
 }
@@ -39,7 +40,6 @@ func New(o Options) Writer {
 // Adding this prompt after the profile prompt ensures that the suggestions are
 // returned in the expected format.
 const prompt = "You will be provided with text or code. Your task is to %s. " +
-	"Focus only on the text, ignoring any code-related words. " +
 	"After making improvements, return a JSON array where each element includes the original text and its corresponding suggestion in this format: { original: \"...\", value: \"...\" }."
 
 func (w *qwriter) Suggestions(text string) ([]Suggestion, error) {
@@ -66,4 +66,8 @@ func (w *qwriter) Apply(text string, suggestions []Suggestion) (string, error) {
 	}
 
 	return text, nil
+}
+
+func (w *qwriter) SetProfile(p Profile) {
+	w.profile = p
 }

--- a/pkg/qwriter/qwriter_test.go
+++ b/pkg/qwriter/qwriter_test.go
@@ -27,7 +27,10 @@ func TestFix(t *testing.T) {
 
 			// Given: a code input with syntax errors.
 			var (
-				client     = qwriter.New(ai.NewOpenAI(os.Getenv("QWRITER_OPENAI_KEY")))
+				client = qwriter.New(qwriter.Options{
+					AI:      ai.NewOpenAI(os.Getenv("QWRITER_OPENAI_KEY")),
+					Profile: qwriter.DefaultProfile,
+				})
 				inputFile  = path.Join("testdata", fmt.Sprintf("%s.input", syntax))
 				goldenFile = path.Join("testdata", fmt.Sprintf("%s.golden", syntax))
 			)


### PR DESCRIPTION
This PR introduces two new features: support for configuration files and the ability to define multiple writing profiles. These enhancements allow users to create and manage different profiles tailored to specific contexts, such as translation assistance, grammar checking, or refining UI copy.

To enable these profiles, the implementation includes support for configuration files in YAML format. Users can define multiple profiles within a single config file, making it easy to switch between different writing contexts.

### Usage:
1. **Create a Configuration File**  
   You can create a configuration file, for example, `.qwriter.yaml`, to define your profiles. The file can be named and located anywhere that suits your project. Here’s an example of defining a profile for UI copy:

   ```yaml
   # .qwriter.yaml
   profiles:
     - name: "ui-copy"
       description: "generate and review text for the UI"
    ```
2. **Run the CLI**  
   With the config file in place, you can pass it to the CLI using the following command. If no profile is specified, QWriter defaults to a simple grammar and spell checker:
   ```bash
   qwriter "improve my text" -c .qwriter.yaml -p ui-copy  
   ```

