### PR TITLE
feat(cli): add copy to clipboard feature

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "makefile.configureOnOpen": false
+}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/BrunoQuaresma/openwritter/pkg/qwriter"
+	"github.com/atotto/clipboard"
 	"github.com/spf13/cobra"
 )
 
@@ -38,6 +39,7 @@ func New(o Options) (*CLI, error) {
 	var (
 		configPath string
 		profile    = qwriter.DefaultProfile.Name
+		copy       bool
 	)
 
 	// Setup
@@ -75,13 +77,22 @@ func New(o Options) (*CLI, error) {
 				return fmt.Errorf("failed to apply suggestions for %s: %w", txt, err)
 			}
 			fmt.Fprintln(cli.stdout, txt)
+
+			if copy {
+				err = clipboard.WriteAll(txt)
+				if err != nil {
+					return fmt.Errorf("failed to copy text to clipboard: %w", err)
+				}
+			}
+
 			return nil
 		},
 	}
 	cli.cmd.SetOut(cli.stdout)
 	cli.cmd.SetErr(cli.stderr)
 	cli.cmd.Flags().StringVarP(&configPath, "config", "c", "", "Path to the QWriter CLI configuration file")
-	cli.cmd.Flags().StringVarP(&profile, "profile", "p", qwriter.DefaultProfile.Name, "	Profile to use for reviewing and generating text")
+	cli.cmd.Flags().StringVarP(&profile, "profile", "p", qwriter.DefaultProfile.Name, "Profile to use for reviewing and generating text")
+	cli.cmd.Flags().BoolVar(&copy, "copy", false, "Copy the reviwed and generated text to the clipboard")
 
 	return cli, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/BrunoQuaresma/openwritter
 go 1.23.0
 
 require (
+	github.com/atotto/clipboard v0.1.4
 	github.com/sashabaranov/go-openai v1.28.1
 	github.com/spf13/cobra v1.8.1
 )
@@ -16,5 +17,5 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.9.0
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
This update introduces a new feature that allows users to copy the output directly to the clipboard by using the `--copy` flag in the CLI.